### PR TITLE
Update config.js

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -48,7 +48,7 @@ module.exports = {
       },
       {
         text: 'Home',
-        link: 'https://docs.passwordless.dev'
+        link: 'https://www.passwordless.dev/'
       }
     ],
     sidebar: {


### PR DESCRIPTION
Both 'Documentation' & 'Home' in the masthead nav lead to docs.passwordless.dev. This is redundant, so I've rerouted 'Home' to the main site. We'll need to change this again when the updated marketing page goes up.