### PR TITLE
Added plausible

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -21,7 +21,8 @@ module.exports = {
     ['link', { rel: 'icon', href: '/favicon.ico' }],
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
     ['meta', { name: 'apple-mobile-web-app-capable', content: 'yes' }],
-    ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }]
+    ['meta', { name: 'apple-mobile-web-app-status-bar-style', content: 'black' }],
+    ["script", { src: "https://plausible.io/js/script.js", "data-domain":'docs.passwordless.dev' }]
   ],
 
   /**


### PR DESCRIPTION
We want to see how many people find their way to our content, so we've added a tracker that we think respect our privacy and doesn't use cookies so that we don't need to add a irritating banner.
