### PR TITLE
Fix "CredentialId" typo

### DIFF
--- a/src/guide/api.md
+++ b/src/guide/api.md
@@ -133,7 +133,7 @@ If successful, the `/signin/verify` endpoint will return a success response obje
   "country": "SE",
   "nickname": "My Work Phone",
   "expiresAt": "3023-08-01T14:43:03Z",
-  "CredentialId": "VCzDJDLuWmj_SrOuT5STsetG6-LUVENWuAkMY9uJXNM",
+  "credentialId": "VCzDJDLuWmj_SrOuT5STsetG6-LUVENWuAkMY9uJXNM",
   "type": "passkey_signin" // or passkey_register  
 }
 ```


### PR DESCRIPTION
When I was calling the API I didn't get anything with "CredentialId" (capital C) but there was a field "credentialId" (lowercase C). I'm assuming this is a typo?

I'm using the `https://v4.passwordless.dev` api.