### PR TITLE
Add missing "tokenId" field

### DIFF
--- a/src/guide/api.md
+++ b/src/guide/api.md
@@ -134,6 +134,7 @@ If successful, the `/signin/verify` endpoint will return a success response obje
   "nickname": "My Work Phone",
   "expiresAt": "3023-08-01T14:43:03Z",
   "CredentialId": "VCzDJDLuWmj_SrOuT5STsetG6-LUVENWuAkMY9uJXNM",
+  "tokenId": "TODO",
   "type": "passkey_signin" // or passkey_register  
 }
 ```


### PR DESCRIPTION
When I use the `/signin/verify` endpoint I get a field called `tokenId` back in the response (see below) which seems to be unlisted in the documentation. I've currently just written `"TODO"`  as the `tokenId` value in the pull request which should be updated to be a proper example value.

```json
{
  "userId": "",
  "timestamp": "",
  "rpid": "",
  "origin": "",
  "success": true,
  "device": "",
  "country": "",
  "nickname": "",
  "credentialId": "",
  "expiresAt": "",
  "tokenId": "",  // <-- HERE
  "type": ""
}
```
